### PR TITLE
Enable asyncio support for python-socks dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ keywords = [
     "http proxy",
 ]
 dependencies = [
-    "python-socks == 2.4.4",
+    "python-socks[asyncio] == 2.4.4",
     "websockets"
 ]
 


### PR DESCRIPTION
This pull request ensures that `pyproject.toml` matches `requirements.txt` in the way it declares dependencies. It solves a problem where `python-socks` listed in `pyproject.toml` didn't have the optional `asyncio` support.

As of now, when I install `websockets_proxy` in a completely new environment using pip, I get the following error.

```
Python 3.10.13 (main, Aug 24 2023, 12:59:26) [Clang 15.0.0 (clang-1500.1.0.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import websockets_proxy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/hoge/venv/lib/python3.10/site-packages/websockets_proxy-0.1.0-py3.10.egg/websockets_proxy/__init__.py", line 1, in <module>
    from .websockets_proxy import proxy_connect, Proxy
  File "/tmp/hoge/venv/lib/python3.10/site-packages/websockets_proxy-0.1.0-py3.10.egg/websockets_proxy/websockets_proxy.py", line 6, in <module>
    from python_socks.async_.asyncio import Proxy
  File "/tmp/hoge/venv/lib/python3.10/site-packages/python_socks-2.4.4-py3.10.egg/python_socks/async_/asyncio/__init__.py", line 1, in <module>
    from ._proxy import AsyncioProxy as Proxy
  File "/tmp/hoge/venv/lib/python3.10/site-packages/python_socks-2.4.4-py3.10.egg/python_socks/async_/asyncio/_proxy.py", line 5, in <module>
    import async_timeout
ModuleNotFoundError: No module named 'async_timeout'
```